### PR TITLE
修复异常

### DIFF
--- a/RoyNet.Server.Login/LoginServer.cs
+++ b/RoyNet.Server.Login/LoginServer.cs
@@ -40,7 +40,11 @@ namespace RoyNet.Server.Login
             var ips = GetIP();
             var uris = ips.Select(ip => new Uri("http://" + ip + ":" + Config.Port)).ToList();
             uris.Add(new Uri("http://127.0.0.1:" + Config.Port));
-            Host = new NancyHost(uris.ToArray());
+            HostConfiguration hostConfigs = new HostConfiguration()
+            {
+                UrlReservations = new UrlReservations() { CreateAutomatically = true }
+            };
+            Host = new NancyHost(hostConfigs, uris.ToArray());
             Host.Start();
         }
 


### PR DESCRIPTION
用vs2013启动项目nancy会报错，抛出异常
Nancy.Hosting.Self.AutomaticUrlReservationCreationFailureException
